### PR TITLE
upgrade dependencies, remove usage deprec. class

### DIFF
--- a/grpcmock-spring-boot/src/main/java/org/grpcmock/springboot/GrpcMockApplicationListener.java
+++ b/grpcmock-spring-boot/src/main/java/org/grpcmock/springboot/GrpcMockApplicationListener.java
@@ -8,7 +8,7 @@ import org.springframework.boot.context.event.ApplicationPreparedEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
-import org.springframework.util.SocketUtils;
+import org.springframework.test.util.TestSocketUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -40,7 +40,7 @@ public class GrpcMockApplicationListener implements ApplicationListener<Applicat
         properties.getSource().put("grpcmock.server.port-dynamic", true);
       }
     } else if (httpPort.equals(0)) {
-      int availablePort = SocketUtils.findAvailableTcpPort();
+      int availablePort = TestSocketUtils.findAvailableTcpPort();
       MapPropertySource properties = ofNullable(environment.getPropertySources().remove("grpcmock"))
           .map(MapPropertySource.class::cast)
           .orElseGet(() -> new MapPropertySource("grpcmock", new HashMap<>()));

--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>
 
-    <grpc.version>1.50.2</grpc.version>
-    <spring-boot.version>2.7.0</spring-boot.version>
+    <grpc.version>1.51.0</grpc.version>
+    <spring-boot.version>2.7.6</spring-boot.version>
     <slf4j.version>1.7.36</slf4j.version>
     <junit-jupiter.version>5.8.2</junit-jupiter.version>
     <assertj.version>3.23.1</assertj.version>


### PR DESCRIPTION
Partially addressed the issue reported here: https://github.com/Fadelis/grpcmock/issues/23

Simply upgrading Spring Boot to the latest release under the 2.7.X branch and removing the usage of the deprecated SocketUtils in favour of TestSocketUtils.

Also upgraded gRPC version to 1.51.