### PR TITLE
Replace @PostConstruct with InitializingBean

### DIFF
--- a/grpcmock-spring-boot/src/main/java/org/grpcmock/springboot/GrpcMockConfiguration.java
+++ b/grpcmock-spring-boot/src/main/java/org/grpcmock/springboot/GrpcMockConfiguration.java
@@ -9,12 +9,12 @@ import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.stream.Stream;
-import javax.annotation.PostConstruct;
 import org.grpcmock.GrpcMock;
 import org.grpcmock.GrpcMockBuilder;
 import org.grpcmock.exception.GrpcMockException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
  */
 @Configuration
 @EnableConfigurationProperties(GrpcMockProperties.class)
-public class GrpcMockConfiguration implements SmartLifecycle {
+public class GrpcMockConfiguration implements SmartLifecycle, InitializingBean {
 
   private static final Logger log = LoggerFactory.getLogger(GrpcMockConfiguration.class);
   private static final String GRPCMOCK_BEAN_NAME = "grpcMock";
@@ -52,8 +52,8 @@ public class GrpcMockConfiguration implements SmartLifecycle {
     this.beanFactory = beanFactory;
   }
 
-  @PostConstruct
-  public void init() {
+  @Override
+  public void afterPropertiesSet() {
     if (isRunning()) {
       resetAll();
       updateGlobalServer();

--- a/grpcmock-spring-boot/src/main/java/org/grpcmock/springboot/GrpcMockTestExecutionListener.java
+++ b/grpcmock-spring-boot/src/main/java/org/grpcmock/springboot/GrpcMockTestExecutionListener.java
@@ -22,7 +22,7 @@ public final class GrpcMockTestExecutionListener extends AbstractTestExecutionLi
       return;
     }
     if (!portOrNameIsFixed(testContext)) {
-      grpcMockConfig(testContext).init();
+      grpcMockConfig(testContext).afterPropertiesSet();
     }
   }
 

--- a/grpcmock-spring-boot/src/test/java/org/grpcmock/springboot/GrpcMockConfigurationTest.java
+++ b/grpcmock-spring-boot/src/test/java/org/grpcmock/springboot/GrpcMockConfigurationTest.java
@@ -38,7 +38,7 @@ class GrpcMockConfigurationTest {
     when(properties.getServer().getInterceptors())
         .thenReturn(new Class[]{MyServerInterceptor.class});
 
-    Assertions.assertThatThrownBy(configuration::init)
+    Assertions.assertThatThrownBy(configuration::afterPropertiesSet)
         .isInstanceOf(GrpcMockException.class)
         .hasMessageContaining("missing no-args constructor");
   }
@@ -47,7 +47,7 @@ class GrpcMockConfigurationTest {
   void should_throw_error_when_cert_chain_is_present_but_private_key_is_missing() {
     when(properties.getServer().getCertChainFile()).thenReturn("my-cert-chain");
 
-    Assertions.assertThatThrownBy(configuration::init)
+    Assertions.assertThatThrownBy(configuration::afterPropertiesSet)
         .isInstanceOf(GrpcMockException.class)
         .hasMessage("Both certChain and privateKey have to be defined");
   }
@@ -56,7 +56,7 @@ class GrpcMockConfigurationTest {
   void should_throw_error_when_private_key_is_present_but_cert_chain_is_missing() {
     when(properties.getServer().getPrivateKeyFile()).thenReturn("my-cert-chain");
 
-    Assertions.assertThatThrownBy(configuration::init)
+    Assertions.assertThatThrownBy(configuration::afterPropertiesSet)
         .isInstanceOf(GrpcMockException.class)
         .hasMessage("Both certChain and privateKey have to be defined");
   }


### PR DESCRIPTION
Spring boot 3 upgraded from javax.* to jakarta.* classes for EE support. And if in a spring boot application there will be no old javax.* dependency, the `@PostConstruct` annotated methods won't be invoked.
This small change allows init method to work in both spring boot 2 and 3 (and even spring boot 1.x 😄 )
What do you think?