### PR TITLE
Reduce coupling in GrpcMockConfiguration

### DIFF
--- a/grpcmock-spring-boot/src/main/java/org/grpcmock/springboot/GrpcMockConfiguration.java
+++ b/grpcmock-spring-boot/src/main/java/org/grpcmock/springboot/GrpcMockConfiguration.java
@@ -18,7 +18,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
@@ -34,7 +33,6 @@ public class GrpcMockConfiguration implements SmartLifecycle {
   private static final String GRPCMOCK_BEAN_NAME = "grpcMock";
 
   private final GrpcMockProperties properties;
-  private final ApplicationContext context;
   private final DefaultListableBeanFactory beanFactory;
 
   private volatile boolean running;
@@ -42,13 +40,8 @@ public class GrpcMockConfiguration implements SmartLifecycle {
   private GrpcMock server;
 
   @Autowired
-  GrpcMockConfiguration(
-      GrpcMockProperties properties,
-      ApplicationContext context,
-      DefaultListableBeanFactory beanFactory
-  ) {
+  GrpcMockConfiguration(GrpcMockProperties properties, DefaultListableBeanFactory beanFactory) {
     this.properties = properties;
-    this.context = context;
     this.beanFactory = beanFactory;
   }
 
@@ -75,7 +68,7 @@ public class GrpcMockConfiguration implements SmartLifecycle {
     // Register executor if present
     Executor executor = ofNullable(properties.getServer().getExecutorBeanName())
         .filter(StringUtils::hasText)
-        .map(name -> context.getBean(name, Executor.class))
+        .map(name -> beanFactory.getBean(name, Executor.class))
         .orElseGet(() -> of(properties.getServer().getExecutorThreadCount())
             .filter(threads -> threads > 0)
             .map(Executors::newFixedThreadPool)

--- a/grpcmock-spring-boot/src/test/java/org/grpcmock/springboot/GrpcMockConfigurationTest.java
+++ b/grpcmock-spring-boot/src/test/java/org/grpcmock/springboot/GrpcMockConfigurationTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
-import org.springframework.context.ApplicationContext;
 
 /**
  * @author Fadelis
@@ -23,10 +22,9 @@ class GrpcMockConfigurationTest {
 
   private final GrpcMockProperties properties = mock(
       GrpcMockProperties.class, Mockito.RETURNS_DEEP_STUBS);
-  private final ApplicationContext context = mock(ApplicationContext.class);
   private final DefaultListableBeanFactory beanFactory = mock(DefaultListableBeanFactory.class);
   private final GrpcMockConfiguration configuration = new GrpcMockConfiguration(
-      properties, context, beanFactory);
+      properties, beanFactory);
 
   @BeforeEach
   void setup() {


### PR DESCRIPTION
Just a very little polishing. It's possible to get beans from factory as well as from application context. So context in this class is redundant.
Less dependencies - easier support, don't you agree?