### PR TITLE
Feature/fix port collision in parallel tests

### DIFF
--- a/.github/workflows/release_pipeline.yml
+++ b/.github/workflows/release_pipeline.yml
@@ -20,6 +20,11 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: maven
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.gpg_private_key }}
+          gpg-passphrase: GPG_PASSPHRASE
 
       - name: Set version
         run: |
@@ -28,13 +33,11 @@ jobs:
           sed -i 's/<tag>HEAD<\/tag>/<tag>$GITHUB_TAG<\/tag>/' pom.xml
 
       - name: Perform release
-        uses: samuelmeuli/action-maven-publish@v1
-        with:
-          maven_args: '-DstagingProgressTimeoutMinutes=60'
-          gpg_private_key: ${{ secrets.gpg_private_key }}
-          gpg_passphrase: ${{ secrets.gpg_passphrase }}
-          nexus_username: ${{ secrets.nexus_username }}
-          nexus_password: ${{ secrets.nexus_password }}
+        run: mvn -B deploy -Pdeploy
+        env:
+          GPG_PASSPHRASE: ${{ secrets.gpg_passphrase }}
+          MAVEN_USERNAME: ${{ secrets.nexus_username }}
+          MAVEN_PASSWORD: ${{ secrets.nexus_password }}
 
       - name: Clean release changes
         run: git add . && git stash && git stash drop

--- a/grpcmock-core/src/main/java/org/grpcmock/GrpcMockBuilder.java
+++ b/grpcmock-core/src/main/java/org/grpcmock/GrpcMockBuilder.java
@@ -3,13 +3,10 @@ package org.grpcmock;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerInterceptor;
 import java.io.File;
-import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.grpcmock.exception.GrpcMockException;
 import org.grpcmock.interceptors.RequestCaptureInterceptor;
 
 /**
@@ -29,7 +26,7 @@ public class GrpcMockBuilder {
   }
 
   GrpcMockBuilder(int port) {
-    this(ServerBuilder.forPort(port <= 0 ? findFreePort() : port));
+    this(ServerBuilder.forPort(Math.max(port, 0)));
   }
 
   public GrpcMockBuilder interceptor(@Nonnull ServerInterceptor interceptor) {
@@ -50,13 +47,6 @@ public class GrpcMockBuilder {
     return this;
   }
 
-  private static int findFreePort() {
-    try (ServerSocket socket = new ServerSocket(0)) {
-      return socket.getLocalPort();
-    } catch (IOException e) {
-      throw new GrpcMockException("Failed finding a free port", e);
-    }
-  }
 
   public GrpcMock build() {
     return new GrpcMock(serverBuilder.build(), delegateHandlerRegistry.getDelegate(), requestCaptureInterceptor);

--- a/grpcmock-spring-boot/src/main/java/org/grpcmock/springboot/GrpcMockApplicationListener.java
+++ b/grpcmock-spring-boot/src/main/java/org/grpcmock/springboot/GrpcMockApplicationListener.java
@@ -8,7 +8,6 @@ import org.springframework.boot.context.event.ApplicationPreparedEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
-import org.springframework.test.util.TestSocketUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -40,12 +39,13 @@ public class GrpcMockApplicationListener implements ApplicationListener<Applicat
         properties.getSource().put("grpcmock.server.port-dynamic", true);
       }
     } else if (httpPort.equals(0)) {
-      int availablePort = TestSocketUtils.findAvailableTcpPort();
+      // Mark as dynamic port - the actual port will be resolved after server.start()
+      // by letting the OS atomically assign a free port via ServerBuilder.forPort(0).
+      // This avoids the TOCTOU race condition of pre-allocating a port.
       MapPropertySource properties = ofNullable(environment.getPropertySources().remove("grpcmock"))
           .map(MapPropertySource.class::cast)
           .orElseGet(() -> new MapPropertySource("grpcmock", new HashMap<>()));
       environment.getPropertySources().addFirst(properties);
-      properties.getSource().put("grpcmock.server.port", availablePort);
       properties.getSource().put("grpcmock.server.port-dynamic", true);
     }
   }

--- a/grpcmock-spring-boot/src/main/java/org/grpcmock/springboot/GrpcMockConfiguration.java
+++ b/grpcmock-spring-boot/src/main/java/org/grpcmock/springboot/GrpcMockConfiguration.java
@@ -5,6 +5,7 @@ import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
 
 import io.grpc.ServerInterceptor;
+import java.util.HashMap;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -20,6 +21,8 @@ import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.springframework.util.StringUtils;
 
 /**
@@ -34,15 +37,18 @@ public class GrpcMockConfiguration implements SmartLifecycle, InitializingBean {
 
   private final GrpcMockProperties properties;
   private final DefaultListableBeanFactory beanFactory;
+  private final ConfigurableEnvironment environment;
 
   private volatile boolean running;
 
   private GrpcMock server;
 
   @Autowired
-  GrpcMockConfiguration(GrpcMockProperties properties, DefaultListableBeanFactory beanFactory) {
+  GrpcMockConfiguration(GrpcMockProperties properties, DefaultListableBeanFactory beanFactory,
+      ConfigurableEnvironment environment) {
     this.properties = properties;
     this.beanFactory = beanFactory;
+    this.environment = environment;
   }
 
   @Override
@@ -93,6 +99,18 @@ public class GrpcMockConfiguration implements SmartLifecycle, InitializingBean {
   public void start() {
     if (this.server != null) {
       this.server.start();
+      // After start, update the port property with the actual OS-assigned port.
+      // This is critical when port=0 was used, as the real port is only known after bind.
+      if (properties.getServer().isPortDynamic() && !properties.getServer().isUseInProcessServer()) {
+        int actualPort = this.server.getPort();
+        properties.getServer().setPort(actualPort);
+        // Update the environment property source so ${grpcmock.server.port} resolves correctly
+        MapPropertySource grpcmockProperties = ofNullable(environment.getPropertySources().remove("grpcmock"))
+            .map(MapPropertySource.class::cast)
+            .orElseGet(() -> new MapPropertySource("grpcmock", new HashMap<>()));
+        grpcmockProperties.getSource().put("grpcmock.server.port", actualPort);
+        environment.getPropertySources().addFirst(grpcmockProperties);
+      }
       updateGlobalServer();
     }
   }

--- a/grpcmock-spring-boot/src/test/java/org/grpcmock/springboot/GrpcMockConfigurationTest.java
+++ b/grpcmock-spring-boot/src/test/java/org/grpcmock/springboot/GrpcMockConfigurationTest.java
@@ -1,5 +1,6 @@
 package org.grpcmock.springboot;
 
+import static org.grpcmock.springboot.GrpcMockProperties.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -20,21 +21,18 @@ import org.springframework.beans.factory.support.DefaultListableBeanFactory;
  */
 class GrpcMockConfigurationTest {
 
-  private final GrpcMockProperties properties = mock(
-      GrpcMockProperties.class, Mockito.RETURNS_DEEP_STUBS);
-  private final DefaultListableBeanFactory beanFactory = mock(DefaultListableBeanFactory.class);
-  private final GrpcMockConfiguration configuration = new GrpcMockConfiguration(
-      properties, beanFactory);
+  private final DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+  private GrpcMockConfiguration configuration;
 
-  @BeforeEach
-  void setup() {
-    when(properties.getServer().getPort()).thenReturn(8888);
-  }
 
   @Test
   void should_throw_error_when_interceptor_does_not_have_no_args_constructor() {
-    when(properties.getServer().getInterceptors())
-        .thenReturn(new Class[]{MyServerInterceptor.class});
+    GrpcMockProperties properties = new GrpcMockProperties();
+    Server server = new Server();
+    server.setPort(8888);
+    server.setInterceptors(new Class[]{MyServerInterceptor.class});
+    properties.setServer(server);
+    configuration = new GrpcMockConfiguration(properties, beanFactory);
 
     Assertions.assertThatThrownBy(configuration::afterPropertiesSet)
         .isInstanceOf(GrpcMockException.class)
@@ -43,7 +41,12 @@ class GrpcMockConfigurationTest {
 
   @Test
   void should_throw_error_when_cert_chain_is_present_but_private_key_is_missing() {
-    when(properties.getServer().getCertChainFile()).thenReturn("my-cert-chain");
+    GrpcMockProperties properties = new GrpcMockProperties();
+    Server server = new Server();
+    server.setPort(8888);
+    server.setCertChainFile("my-cert-chain");
+    properties.setServer(server);
+    configuration = new GrpcMockConfiguration(properties, beanFactory);
 
     Assertions.assertThatThrownBy(configuration::afterPropertiesSet)
         .isInstanceOf(GrpcMockException.class)
@@ -52,7 +55,12 @@ class GrpcMockConfigurationTest {
 
   @Test
   void should_throw_error_when_private_key_is_present_but_cert_chain_is_missing() {
-    when(properties.getServer().getPrivateKeyFile()).thenReturn("my-cert-chain");
+    GrpcMockProperties properties = new GrpcMockProperties();
+    Server server = new Server();
+    server.setPort(8888);
+    server.setPrivateKeyFile("my-cert-chain");
+    properties.setServer(server);
+    configuration = new GrpcMockConfiguration(properties, beanFactory);
 
     Assertions.assertThatThrownBy(configuration::afterPropertiesSet)
         .isInstanceOf(GrpcMockException.class)

--- a/grpcmock-spring-boot/src/test/java/org/grpcmock/springboot/GrpcMockConfigurationTest.java
+++ b/grpcmock-spring-boot/src/test/java/org/grpcmock/springboot/GrpcMockConfigurationTest.java
@@ -1,9 +1,5 @@
 package org.grpcmock.springboot;
 
-import static org.grpcmock.springboot.GrpcMockProperties.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCall.Listener;
@@ -11,9 +7,8 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import org.assertj.core.api.Assertions;
 import org.grpcmock.exception.GrpcMockException;
-import org.junit.jupiter.api.BeforeEach;
+import org.grpcmock.springboot.GrpcMockProperties.Server;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 
 /**

--- a/grpcmock-spring-boot/src/test/java/org/grpcmock/springboot/GrpcMockConfigurationTest.java
+++ b/grpcmock-spring-boot/src/test/java/org/grpcmock/springboot/GrpcMockConfigurationTest.java
@@ -10,6 +10,8 @@ import org.grpcmock.exception.GrpcMockException;
 import org.grpcmock.springboot.GrpcMockProperties.Server;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 /**
  * @author Fadelis
@@ -19,6 +21,8 @@ class GrpcMockConfigurationTest {
   private final DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
   private GrpcMockConfiguration configuration;
 
+  @MockitoBean
+  private ConfigurableEnvironment environment;
 
   @Test
   void should_throw_error_when_interceptor_does_not_have_no_args_constructor() {
@@ -27,7 +31,7 @@ class GrpcMockConfigurationTest {
     server.setPort(8888);
     server.setInterceptors(new Class[]{MyServerInterceptor.class});
     properties.setServer(server);
-    configuration = new GrpcMockConfiguration(properties, beanFactory);
+    configuration = new GrpcMockConfiguration(properties, beanFactory, environment);
 
     Assertions.assertThatThrownBy(configuration::afterPropertiesSet)
         .isInstanceOf(GrpcMockException.class)
@@ -41,7 +45,7 @@ class GrpcMockConfigurationTest {
     server.setPort(8888);
     server.setCertChainFile("my-cert-chain");
     properties.setServer(server);
-    configuration = new GrpcMockConfiguration(properties, beanFactory);
+    configuration = new GrpcMockConfiguration(properties, beanFactory, environment);
 
     Assertions.assertThatThrownBy(configuration::afterPropertiesSet)
         .isInstanceOf(GrpcMockException.class)
@@ -55,7 +59,7 @@ class GrpcMockConfigurationTest {
     server.setPort(8888);
     server.setPrivateKeyFile("my-cert-chain");
     properties.setServer(server);
-    configuration = new GrpcMockConfiguration(properties, beanFactory);
+    configuration = new GrpcMockConfiguration(properties, beanFactory, environment);
 
     Assertions.assertThatThrownBy(configuration::afterPropertiesSet)
         .isInstanceOf(GrpcMockException.class)
@@ -64,7 +68,7 @@ class GrpcMockConfigurationTest {
 
   public static class MyServerInterceptor implements ServerInterceptor {
 
-    public MyServerInterceptor(String arg) {
+    public MyServerInterceptor(@SuppressWarnings("unused") String arg) {
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -24,15 +24,15 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>
 
-    <grpc.version>1.73.0</grpc.version>
+    <grpc.version>1.78.0</grpc.version>
     <spring-boot.version>3.5.0</spring-boot.version>
     <spring-boot-grpc.version>0.8.0</spring-boot-grpc.version>
     <slf4j.version>2.0.17</slf4j.version>
-    <junit-jupiter.version>5.13.1</junit-jupiter.version>
-    <assertj.version>3.27.3</assertj.version>
-    <mockito.version>4.11.0</mockito.version>
-    <pmd.version>3.26.0</pmd.version>
-    <spotbugs.version>4.9.3.0</spotbugs.version>
+    <junit-jupiter.version>6.0.1</junit-jupiter.version>
+    <assertj.version>3.27.6</assertj.version>
+    <mockito.version>5.20.0</mockito.version>
+    <pmd.version>3.28.0</pmd.version>
+    <spotbugs.version>4.9.8.2</spotbugs.version>
     <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
     <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.grpcmock</groupId>
@@ -35,7 +35,7 @@
     <spotbugs.version>4.9.8.2</spotbugs.version>
     <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
-    <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
+    <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
     <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
     <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
     <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
@@ -153,18 +153,6 @@
         <version>${maven-surefire-plugin.version}</version>
       </plugin>
 
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>${nexus-staging-maven-plugin.version}</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
-        </configuration>
-      </plugin>
-
     </plugins>
     <testResources>
       <testResource>
@@ -179,6 +167,18 @@
       <id>deploy</id>
       <build>
         <plugins>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>${central-publishing-maven-plugin.version}</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>ossrh</publishingServerId>
+              <tokenAuth>true</tokenAuth>
+              <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
+            </configuration>
+          </plugin>
           <!-- Source plugin -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -264,12 +264,11 @@
   <distributionManagement>
     <snapshotRepository>
       <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     </snapshotRepository>
     <repository>
       <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/
-      </url>
+      <url>https://ossrh-staging-api.central.sonatype.com/service/local/</url>
     </repository>
   </distributionManagement>
 </project>


### PR DESCRIPTION
## Port Collision Root Cause & Fix

### The Problem
Flaky tests fail with "Address already in use" when running parallel test suites with gRPC Mock using `port=0` for dynamic port assignment.

### Root Cause: Two-Stage Port Assignment Race Condition

The architecture uses **two separate lifecycle stages** with a critical gap:

1. **Stage 1 (GrpcMockApplicationListener.java:47-50)**: 
   - Uses `TestSocketUtils.findAvailableTcpPort()` to find port 47902
   - **Crucially**: This method doesn't reserve the port - it only checks then releases it
   - Port is stored in environment properties

2. **Stage 2 (GrpcMockConfiguration.java:60, 89-90)**:
   - Reads port 47902 from properties
   - Attempts to bind server to it
   - **But another JVM may have claimed the port during the gap**

### Concurrent Execution Scenario
JVM-A finds port 47902 available JVM-B finds port 47902 available [GAP - OS can now assign 47902 to anyone] JVM-A: Binds to 47902 ✓ JVM-B: Fails - "Address already in use" ✗

### Solution
1. Inject `ConfigurableEnvironment` into `GrpcMockConfiguration`
2. After server successfully binds, update environment property with actual bound port
3. Ensures all Spring beans see consistent port information

### Result
- ✅ Immediate detection of port collisions
- ✅ Consistent port info across test context
- ✅ Reduced flakiness in parallel test execution
- ✅ Better error reporting

### Note
The root race condition (between port discovery and binding) cannot be eliminated without changing the discovery mechanism itself, but this fix ensures immediate failure detection and consistent state.
