### PR TITLE
Fix port collision issue while running tests in parallel

### DIFF
--- a/grpcmock-core/src/main/java/org/grpcmock/GrpcMockBuilder.java
+++ b/grpcmock-core/src/main/java/org/grpcmock/GrpcMockBuilder.java
@@ -3,13 +3,10 @@ package org.grpcmock;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerInterceptor;
 import java.io.File;
-import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.grpcmock.exception.GrpcMockException;
 import org.grpcmock.interceptors.RequestCaptureInterceptor;
 
 /**
@@ -29,7 +26,7 @@ public class GrpcMockBuilder {
   }
 
   GrpcMockBuilder(int port) {
-    this(ServerBuilder.forPort(port <= 0 ? findFreePort() : port));
+    this(ServerBuilder.forPort(Math.max(port, 0)));
   }
 
   public GrpcMockBuilder interceptor(@Nonnull ServerInterceptor interceptor) {
@@ -50,13 +47,6 @@ public class GrpcMockBuilder {
     return this;
   }
 
-  private static int findFreePort() {
-    try (ServerSocket socket = new ServerSocket(0)) {
-      return socket.getLocalPort();
-    } catch (IOException e) {
-      throw new GrpcMockException("Failed finding a free port", e);
-    }
-  }
 
   public GrpcMock build() {
     return new GrpcMock(serverBuilder.build(), delegateHandlerRegistry.getDelegate(), requestCaptureInterceptor);

--- a/grpcmock-spring-boot/src/main/java/org/grpcmock/springboot/GrpcMockApplicationListener.java
+++ b/grpcmock-spring-boot/src/main/java/org/grpcmock/springboot/GrpcMockApplicationListener.java
@@ -8,7 +8,6 @@ import org.springframework.boot.context.event.ApplicationPreparedEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
-import org.springframework.test.util.TestSocketUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -40,12 +39,13 @@ public class GrpcMockApplicationListener implements ApplicationListener<Applicat
         properties.getSource().put("grpcmock.server.port-dynamic", true);
       }
     } else if (httpPort.equals(0)) {
-      int availablePort = TestSocketUtils.findAvailableTcpPort();
+      // Mark as dynamic port - the actual port will be resolved after server.start()
+      // by letting the OS atomically assign a free port via ServerBuilder.forPort(0).
+      // This avoids the TOCTOU race condition of pre-allocating a port.
       MapPropertySource properties = ofNullable(environment.getPropertySources().remove("grpcmock"))
           .map(MapPropertySource.class::cast)
           .orElseGet(() -> new MapPropertySource("grpcmock", new HashMap<>()));
       environment.getPropertySources().addFirst(properties);
-      properties.getSource().put("grpcmock.server.port", availablePort);
       properties.getSource().put("grpcmock.server.port-dynamic", true);
     }
   }

--- a/grpcmock-spring-boot/src/main/java/org/grpcmock/springboot/GrpcMockConfiguration.java
+++ b/grpcmock-spring-boot/src/main/java/org/grpcmock/springboot/GrpcMockConfiguration.java
@@ -5,6 +5,7 @@ import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
 
 import io.grpc.ServerInterceptor;
+import java.util.HashMap;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -20,6 +21,8 @@ import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.springframework.util.StringUtils;
 
 /**
@@ -34,15 +37,18 @@ public class GrpcMockConfiguration implements SmartLifecycle, InitializingBean {
 
   private final GrpcMockProperties properties;
   private final DefaultListableBeanFactory beanFactory;
+  private final ConfigurableEnvironment environment;
 
   private volatile boolean running;
 
   private GrpcMock server;
 
   @Autowired
-  GrpcMockConfiguration(GrpcMockProperties properties, DefaultListableBeanFactory beanFactory) {
+  GrpcMockConfiguration(GrpcMockProperties properties, DefaultListableBeanFactory beanFactory,
+      ConfigurableEnvironment environment) {
     this.properties = properties;
     this.beanFactory = beanFactory;
+    this.environment = environment;
   }
 
   @Override
@@ -93,6 +99,18 @@ public class GrpcMockConfiguration implements SmartLifecycle, InitializingBean {
   public void start() {
     if (this.server != null) {
       this.server.start();
+      // After start, update the port property with the actual OS-assigned port.
+      // This is critical when port=0 was used, as the real port is only known after bind.
+      if (properties.getServer().isPortDynamic() && !properties.getServer().isUseInProcessServer()) {
+        int actualPort = this.server.getPort();
+        properties.getServer().setPort(actualPort);
+        // Update the environment property source so ${grpcmock.server.port} resolves correctly
+        MapPropertySource grpcmockProperties = ofNullable(environment.getPropertySources().remove("grpcmock"))
+            .map(MapPropertySource.class::cast)
+            .orElseGet(() -> new MapPropertySource("grpcmock", new HashMap<>()));
+        grpcmockProperties.getSource().put("grpcmock.server.port", actualPort);
+        environment.getPropertySources().addFirst(grpcmockProperties);
+      }
       updateGlobalServer();
     }
   }

--- a/grpcmock-spring-boot/src/test/java/org/grpcmock/springboot/GrpcMockConfigurationTest.java
+++ b/grpcmock-spring-boot/src/test/java/org/grpcmock/springboot/GrpcMockConfigurationTest.java
@@ -10,6 +10,8 @@ import org.grpcmock.exception.GrpcMockException;
 import org.grpcmock.springboot.GrpcMockProperties.Server;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 /**
  * @author Fadelis
@@ -19,6 +21,8 @@ class GrpcMockConfigurationTest {
   private final DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
   private GrpcMockConfiguration configuration;
 
+  @MockitoBean
+  private ConfigurableEnvironment environment;
 
   @Test
   void should_throw_error_when_interceptor_does_not_have_no_args_constructor() {
@@ -27,7 +31,7 @@ class GrpcMockConfigurationTest {
     server.setPort(8888);
     server.setInterceptors(new Class[]{MyServerInterceptor.class});
     properties.setServer(server);
-    configuration = new GrpcMockConfiguration(properties, beanFactory);
+    configuration = new GrpcMockConfiguration(properties, beanFactory, environment);
 
     Assertions.assertThatThrownBy(configuration::afterPropertiesSet)
         .isInstanceOf(GrpcMockException.class)
@@ -41,7 +45,7 @@ class GrpcMockConfigurationTest {
     server.setPort(8888);
     server.setCertChainFile("my-cert-chain");
     properties.setServer(server);
-    configuration = new GrpcMockConfiguration(properties, beanFactory);
+    configuration = new GrpcMockConfiguration(properties, beanFactory, environment);
 
     Assertions.assertThatThrownBy(configuration::afterPropertiesSet)
         .isInstanceOf(GrpcMockException.class)
@@ -55,7 +59,7 @@ class GrpcMockConfigurationTest {
     server.setPort(8888);
     server.setPrivateKeyFile("my-cert-chain");
     properties.setServer(server);
-    configuration = new GrpcMockConfiguration(properties, beanFactory);
+    configuration = new GrpcMockConfiguration(properties, beanFactory, environment);
 
     Assertions.assertThatThrownBy(configuration::afterPropertiesSet)
         .isInstanceOf(GrpcMockException.class)
@@ -64,7 +68,7 @@ class GrpcMockConfigurationTest {
 
   public static class MyServerInterceptor implements ServerInterceptor {
 
-    public MyServerInterceptor(String arg) {
+    public MyServerInterceptor(@SuppressWarnings("unused") String arg) {
     }
 
     @Override

--- a/grpcmock-spring-boot/src/test/java/org/grpcmock/springboot/GrpcMockTestDynamicPortResetSecond.java
+++ b/grpcmock-spring-boot/src/test/java/org/grpcmock/springboot/GrpcMockTestDynamicPortResetSecond.java
@@ -1,5 +1,6 @@
 package org.grpcmock.springboot;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.grpcmock.GrpcMock.response;
 import static org.grpcmock.GrpcMock.stubFor;
 import static org.grpcmock.GrpcMock.unaryMethod;
@@ -28,5 +29,14 @@ class GrpcMockTestDynamicPortResetSecond extends TestBase {
         .willReturn(response(response)));
 
     runAndAssertHealthCheckRequest(response);
+
+    assertThat(grpcMockPort)
+        .as("Port should be assigned by OS (should not be 0)")
+        .isGreaterThan(0)
+        .isLessThan(65536);
+
+    assertThat(grpcMock.getPort())
+        .as("Server's actual port should match injected port property")
+        .isEqualTo(grpcMockPort);
   }
 }

--- a/grpcmock-spring-boot/src/test/java/org/grpcmock/springboot/TestBase.java
+++ b/grpcmock-spring-boot/src/test/java/org/grpcmock/springboot/TestBase.java
@@ -13,14 +13,23 @@ import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
 import io.grpc.health.v1.HealthGrpc;
 import io.grpc.health.v1.HealthGrpc.HealthBlockingStub;
 import io.grpc.inprocess.InProcessChannelBuilder;
+import org.grpcmock.GrpcMock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
 /**
  * @author Fadelis
  */
 abstract class TestBase {
+
+  private static final Logger log = LoggerFactory.getLogger(TestBase.class);
+
+  @Autowired
+  protected GrpcMock grpcMock;
 
   @Value("${grpcmock.server.port}")
   protected int grpcMockPort;
@@ -50,6 +59,7 @@ abstract class TestBase {
   }
 
   void runAndAssertHealthCheckRequest(HealthCheckResponse response) {
+    log.info("Using port: {}", grpcMockPort);
     HealthBlockingStub serviceStub = HealthGrpc.newBlockingStub(serverChannel);
 
     assertThat(serviceStub.check(HealthCheckRequest.getDefaultInstance())).isEqualTo(response);


### PR DESCRIPTION
## Port Collision Root Cause & Fix

### The Problem
Flaky tests fail with "Address already in use" when running parallel test.
```
Caused by:
        org.springframework.context.ApplicationContextException: Failed to start bean 'org.grpcmock.springboot.GrpcMockConfiguration'
            at app//org.springframework.context.support.DefaultLifecycleProcessor.doStart(DefaultLifecycleProcessor.java:408)
            at app//org.springframework.context.support.DefaultLifecycleProcessor.doStart(DefaultLifecycleProcessor.java:394)
            at app//org.springframework.context.support.DefaultLifecycleProcessor$LifecycleGroup.start(DefaultLifecycleProcessor.java:586)
            at java.base@17.0.18/java.lang.Iterable.forEach(Iterable.java:75)
            at app//org.springframework.context.support.DefaultLifecycleProcessor.startBeans(DefaultLifecycleProcessor.java:364)
            at app//org.springframework.context.support.DefaultLifecycleProcessor.onRefresh(DefaultLifecycleProcessor.java:310)
            at app//org.springframework.context.support.AbstractApplicationContext.finishRefresh(AbstractApplicationContext.java:1006)
            at app//org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:630)
            at app//org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:146)
            at app//org.springframework.boot.SpringApplication.refresh(SpringApplication.java:752)
            at app//org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:439)
            at app//org.springframework.boot.SpringApplication.run(SpringApplication.java:318)
            at app//org.springframework.boot.test.context.SpringBootContextLoader.lambda$loadContext$3(SpringBootContextLoader.java:144)
            at app//org.springframework.util.function.ThrowingSupplier.get(ThrowingSupplier.java:58)
            at app//org.springframework.util.function.ThrowingSupplier.get(ThrowingSupplier.java:46)
            at app//org.springframework.boot.SpringApplication.withHook(SpringApplication.java:1461)
            at app//org.springframework.boot.test.context.SpringBootContextLoader$ContextLoaderHook.run(SpringBootContextLoader.java:563)
            at app//org.springframework.boot.test.context.SpringBootContextLoader.loadContext(SpringBootContextLoader.java:144)
            at app//org.springframework.boot.test.context.SpringBootContextLoader.loadContext(SpringBootContextLoader.java:110)
            at app//org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContextInternal(DefaultCacheAwareContextLoaderDelegate.java:225)
            at app//org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContext(DefaultCacheAwareContextLoaderDelegate.java:152)
            ... 19 more

            Caused by:
            org.grpcmock.exception.GrpcMockException: failed to start gRPC Mock server
                at app//org.grpcmock.GrpcMock.start(GrpcMock.java:118)
                at app//org.grpcmock.springboot.GrpcMockConfiguration.start(GrpcMockConfiguration.java:95)
                at app//org.springframework.context.support.DefaultLifecycleProcessor.doStart(DefaultLifecycleProcessor.java:405)
                ... 39 more

                Caused by:
                java.io.IOException: Failed to bind to address 0.0.0.0/0.0.0.0:44818
                    at io.grpc.netty.shaded.io.grpc.netty.NettyServer.start(NettyServer.java:341)
                    at io.grpc.internal.ServerImpl.start(ServerImpl.java:185)
                    at io.grpc.internal.ServerImpl.start(ServerImpl.java:94)
                    at org.grpcmock.GrpcMock.start(GrpcMock.java:114)
                    ... 41 more

                    Caused by:
                    io.grpc.netty.shaded.io.netty.channel.unix.Errors$NativeIoException: bind(..) failed: Address already in use
```

### Root Cause: Two-Stage Port Assignment Race Condition

The architecture uses **two separate lifecycle stages** with a critical gap:

1. **Stage 1 (GrpcMockApplicationListener.java:47-50)**: 
   - Uses `TestSocketUtils.findAvailableTcpPort()` to find port 47902
   - **Crucially**: This method doesn't reserve the port - it only checks then releases it
   - Port is stored in environment properties

2. **Stage 2 (GrpcMockConfiguration.java:60, 89-90)**:
   - Reads port 47902 from properties
   - Attempts to bind server to it
   - **But another JVM may have claimed the port during the gap**


### Solution
In `GrpcMockApplicationListenerMark`, don't find port instead mark dynamic port - the actual port will be resolved after `server.start()` by letting the OS atomically assign a free port via ServerBuilder.forPort(0).


### Note
The root race condition (between port discovery and binding) cannot be eliminated without changing the discovery mechanism itself, but this fix ensures immediate failure detection and consistent state.
